### PR TITLE
Conditionally skip nba api test

### DIFF
--- a/nbagrid_api_app/tests/test_game.py
+++ b/nbagrid_api_app/tests/test_game.py
@@ -1,5 +1,7 @@
-from django.test import TestCase
+from django.test import TestCase, tag
 from django.db.models import F
+from unittest import skipUnless
+import sys
 
 from nbagrid_api_app.GameBuilder import GameBuilder
 from nbagrid_api_app.models import Player, Team, GameResult, GameFilterDB
@@ -124,6 +126,8 @@ class PlayerTest(TestCase):
         player = Player.objects.create(stats_id=1, name='Lebron James')
         self.assertFalse(player.has_played_for_team('CLE'))
         
+    @tag('nba_api_access')
+    @skipUnless('--tag=nba_api_access' in sys.argv or 'nba_api_access' in sys.argv, 'NBA API access required - run with --tag=nba_api_access')
     def test_load_player_data(self):
         #player = Player.objects.create(stats_id=202681, name='Kyrie Irving')
         #player = Player.objects.create(stats_id=2544, name='LeBron James')


### PR DESCRIPTION
Skip `test_load_player_data` by default as it requires external NBA API access.

This test is now tagged `nba_api_access` and will only run when explicitly called with `--tag=nba_api_access`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4ea7fa3-c6c8-478c-aa0a-70b5d505b2fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4ea7fa3-c6c8-478c-aa0a-70b5d505b2fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>