### PR TITLE
Add admin panel link to game page

### DIFF
--- a/nbagrid_api_app/templates/game.html
+++ b/nbagrid_api_app/templates/game.html
@@ -1060,6 +1060,19 @@
             background-color: #555;
         }
 
+        /* Admin link - tinted down styling */
+        .btn-admin {
+            background-color: #2a2a2a;
+            color: #666;
+            font-size: 14px;
+            opacity: 0.7;
+        }
+        .btn-admin:hover {
+            background-color: #333;
+            color: #888;
+            opacity: 0.9;
+        }
+
         /* Button spacing */
         .btn-mt {
             margin-top: 20px;
@@ -1225,6 +1238,7 @@
             <button class="btn btn-secondary" disabled>All Grids Played...</button>
             {% endif %}
             <button class="btn btn-secondary" onclick="openAboutModal()">About</button>
+            <a href="/admin/" class="btn btn-admin">Admin</a>
         </footer>
     </main>
 


### PR DESCRIPTION
Add a tinted-down admin link to the game page footer.

This PR addresses issue #10 by providing a subtle link to the `/admin` panel at the bottom of the game page, ensuring it doesn't distract typical users.

---
<a href="https://cursor.com/background-agent?bcId=bc-e077d461-4fd8-41fa-a124-b483bdc701c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e077d461-4fd8-41fa-a124-b483bdc701c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>