### PR TITLE
Add back to NBAGrid link to admin panel

### DIFF
--- a/nbagrid_api_app/templates/admin/base_site.html
+++ b/nbagrid_api_app/templates/admin/base_site.html
@@ -1,0 +1,18 @@
+{% extends "admin/base.html" %}
+{% load i18n static %}
+
+{% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block branding %}
+<h1 id="site-name">
+    <a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a>
+</h1>
+{% endblock %}
+
+{% block nav-global %}
+<div style="float: right; margin-top: 5px;">
+    <a href="{% url 'index' %}" style="color: #ffc; text-decoration: none; font-weight: bold; background: rgba(255,255,255,0.1); padding: 5px 10px; border-radius: 3px;">
+        ← Back to NBAGrid
+    </a>
+</div>
+{% endblock %}


### PR DESCRIPTION
Add a "Back to NBAGrid" link to the admin panel for one-click navigation to the game page, as requested in issue #9.

---
<a href="https://cursor.com/background-agent?bcId=bc-d476cdd3-af05-4459-96ae-b4d3b410f780">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d476cdd3-af05-4459-96ae-b4d3b410f780">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>